### PR TITLE
Adds set_gateway option

### DIFF
--- a/pybootd/__init__.py
+++ b/pybootd/__init__.py
@@ -46,6 +46,7 @@ def pybootd_path(path):
     elif os.path.exists(path):
         newpath = path
     else:
+        from pkg_resources import DistributionNotFound
         try:
             from pkg_resources import Requirement, resource_filename
             newpath = resource_filename(Requirement.parse(PRODUCT_NAME), path)
@@ -53,6 +54,8 @@ def pybootd_path(path):
                 from pkg_resources import get_distribution
                 localpath = get_distribution(PRODUCT_NAME).location
                 newpath = os.path.join(localpath, path)
+        except DistributionNotFound:
+            newpath = path
         except KeyError:
             raise IOError('No such file or directory (resource)')
     if not os.path.isfile(newpath) and not os.path.isdir(newpath):

--- a/pybootd/etc/pybootd.ini
+++ b/pybootd/etc/pybootd.ini
@@ -15,6 +15,7 @@ access = mac
 allow_simple_dhcp = enable
 dns = 10.130.0.2
 boot_file = pxelinux.0
+set_gateway = true
 ; use "nc -l -u 127.0.0.1 -p 12345" to debug
 ; notify = 192.168.26.201:12345;192.168.26.200:12345
 

--- a/pybootd/pxed.py
+++ b/pybootd/pxed.py
@@ -471,13 +471,20 @@ class BootpServer:
                 self.log.info('Lease for MAC %s already defined as IP %s' % \
                                 (mac_str, ip))
             else:
-                for idx in xrange(self.pool_count):
-                    ipkey = inttoip(ipaddr+idx)
-                    self.log.debug('Check for IP %s' % ipkey)
-                    if ipkey not in self.ippool.values():
-                        self.ippool[mac_str] = ipkey
-                        ip = ipkey
-                        break
+                ip = self.config.get(mac_str.lower(), "ipv4")
+                if ip:
+                    self.ippool[mac_str] = ip
+                    self.log.info('Found reserved IP "%s" for MAC "%s"' %
+                                  (ip, mac_str))
+                else:
+                    self.log.debug("No reserved IP found for MAC %s" % mac_str)
+                    for idx in xrange(self.pool_count):
+                        ipkey = inttoip(ipaddr+idx)
+                        self.log.debug('Check for IP %s' % ipkey)
+                        if ipkey not in self.ippool.values():
+                            self.ippool[mac_str] = ipkey
+                            ip = ipkey
+                            break
             if not ip:
                 raise BootpError('No more IP available in definined pool')
 

--- a/pybootd/pxed.py
+++ b/pybootd/pxed.py
@@ -544,7 +544,10 @@ class BootpServer:
         pkt += struct.pack('!BB4s', DHCP_SERVER, 4, server)
         mask = socket.inet_aton(self.netconfig['mask'])
         pkt += struct.pack('!BB4s', DHCP_IP_MASK, 4, mask)
-        pkt += struct.pack('!BB4s', DHCP_IP_GATEWAY, 4, server)
+
+        if to_bool(self.config.get(self.bootp_section, 'set_gateway', True)):
+            pkt += struct.pack('!BB4s', DHCP_IP_GATEWAY, 4, server)
+
         dns = self.config.get(self.bootp_section,
                               'dns', None)
         if dns:

--- a/pybootd/pxed.py
+++ b/pybootd/pxed.py
@@ -185,9 +185,14 @@ class BootpServer:
             raise BootpError('Missing pool_start definition')
         self.pool_count = int(self.config.get(self.bootp_section,
                               'pool_count', '10'))
+
         self.netconfig = get_iface_config(self.pool_start)
         if not self.netconfig:
+            host = self.config.get(self.bootp_section, 'address', '0.0.0.0')
+            self.netconfig = get_iface_config(host)
+        if not self.netconfig:
             raise BootpError('Unable to detect network configuration')
+
         keys = sorted(self.netconfig.keys())
         self.log.info('Using %s' % ', '.join(map(':'.join,
                                 zip(keys, [self.netconfig[k] for k in keys]))))
@@ -454,6 +459,7 @@ class BootpServer:
             self.log.info('%s access is authorized, '
                           'request will be satisfied' % item)
         # construct reply
+        buf[BOOTP_HOPS] = 0
         buf[BOOTP_OP] = BOOTREPLY
         self.log.info('Client IP: %s' % socket.inet_ntoa(buf[7]))
         if buf[BOOTP_CIADDR] == '\x00\x00\x00\x00':
@@ -474,18 +480,28 @@ class BootpServer:
                         break
             if not ip:
                 raise BootpError('No more IP available in definined pool')
-            mask = iptoint(self.netconfig['mask'])
+
+            #mask = iptoint(self.config.get(
+            #    self.bootp_section, 'netmask', self.netconfig['mask']))
+            #mask = iptoint(self.netconfig['mask'])
+            mask = iptoint("0.0.0.0")
+
             reply_broadcast = iptoint(ip) & mask
             reply_broadcast |= (~mask)&((1<<32)-1)
             buf[BOOTP_YIADDR] = socket.inet_aton(ip)
             buf[BOOTP_SECS] = 0
-            buf[BOOTP_FLAGS] = BOOTP_FLAGS_NONE
-            addr = (inttoip(reply_broadcast), addr[1])
-            self.log.debug('Reply to: %s:%s' % addr)
+            buf[BOOTP_FLAGS] = BOOTP_FLAGS_BROADCAST
+
+            relay = buf[BOOTP_GIADDR]
+            if relay != b'\x00\x00\x00\x00':
+                addr = (socket.inet_ntoa(relay), addr[1])
+            else:
+                addr = (inttoip(reply_broadcast), addr[1])
+            self.log.info('Reply to: %s:%s' % addr)
         else:
             buf[BOOTP_YIADDR] = buf[BOOTP_CIADDR]
             ip = socket.inet_ntoa(buf[BOOTP_YIADDR])
-        buf[BOOTP_SIADDR] = buf[BOOTP_GIADDR] = socket.inet_aton(server_addr)
+        buf[BOOTP_SIADDR] = socket.inet_aton(server_addr)
         # sname
         buf[BOOTP_SNAME] = \
             '.'.join([self.config.get(self.bootp_section,
@@ -542,11 +558,15 @@ class BootpServer:
         pkt += struct.pack('!BBB', DHCP_MSG, 1, dhcp_reply)
         server = socket.inet_aton(server_addr)
         pkt += struct.pack('!BB4s', DHCP_SERVER, 4, server)
-        mask = socket.inet_aton(self.netconfig['mask'])
+
+        mask = socket.inet_aton(self.config.get(
+            self.bootp_section, 'netmask', self.netconfig['mask']))
+
         pkt += struct.pack('!BB4s', DHCP_IP_MASK, 4, mask)
 
         if to_bool(self.config.get(self.bootp_section, 'set_gateway', True)):
-            gateway = self.config.get(self.bootp_section, 'gateway', server)
+            gateway = socket.inet_aton(
+                self.config.get(self.bootp_section, 'gateway', server_addr))
             pkt += struct.pack('!BB4s', DHCP_IP_GATEWAY, 4, gateway)
 
         dns = self.config.get(self.bootp_section,

--- a/pybootd/pxed.py
+++ b/pybootd/pxed.py
@@ -546,7 +546,8 @@ class BootpServer:
         pkt += struct.pack('!BB4s', DHCP_IP_MASK, 4, mask)
 
         if to_bool(self.config.get(self.bootp_section, 'set_gateway', True)):
-            pkt += struct.pack('!BB4s', DHCP_IP_GATEWAY, 4, server)
+            gateway = self.config.get(self.bootp_section, 'gateway', server)
+            pkt += struct.pack('!BB4s', DHCP_IP_GATEWAY, 4, gateway)
 
         dns = self.config.get(self.bootp_section,
                               'dns', None)

--- a/pybootd/util.py
+++ b/pybootd/util.py
@@ -135,8 +135,13 @@ def get_iface_config(address):
         if netifaces.AF_INET not in ifinfo:
             continue
         for inetinfo in netifaces.ifaddresses(iface)[netifaces.AF_INET]:
-            addr = iptoint(inetinfo['addr'])
-            mask = iptoint(inetinfo['netmask'])
+            addr_s = inetinfo.get('addr')
+            netmask_s = inetinfo.get('netmask')
+            if addr_s is None or netmask_s is None:
+                continue
+
+            addr = iptoint(addr_s)
+            mask = iptoint(netmask_s)
             ip = addr & mask
             ip_client = pool & mask
             delta = ip ^ ip_client


### PR DESCRIPTION
The DHCP gatewy option should not be set in cases in which the
interface where pybootd is bound in not meant to act as the gateway
for the host booted via PXE.