### PR TITLE
Added always_check option for http auth

### DIFF
--- a/pybootd/etc/pybootd.ini
+++ b/pybootd/etc/pybootd.ini
@@ -29,6 +29,7 @@ boot_file = pxelinux.0
 location = 127.0.0.1:13400
 pxe = boot
 dhcp = linux
+always_check = disable
 
 [tftp]
 ;address = (use address from bootpd)

--- a/pybootd/pxed.py
+++ b/pybootd/pxed.py
@@ -394,6 +394,7 @@ class BootpServer:
                 netloc = self.config.get(self.access, 'location')
                 path = self.config.get(self.access, pxe and 'pxe' or 'dhcp')
                 timeout = int(self.config.get(self.access, 'timeout', '5'))
+                always_check = self.config.get(self.access, 'always_check')
                 parameters = {'mac' : mac_str}
                 if uuid:
                     parameters['uuid'] = uuid_str
@@ -402,7 +403,10 @@ class BootpServer:
                 item = uuid_str or mac_str
                 # only bother the authentication host when a state change is
                 # required.
-                if currentstate != newstate:
+                checkhost = currentstate != newstate
+                if to_bool(always_check):
+                  checkhost = True
+                if checkhost:
                     query = urllib.urlencode(parameters)
                     urlparts = (self.access, netloc, path, query, '')
                     url = urlparse.urlunsplit(urlparts)


### PR DESCRIPTION
I have a need for a project I'm working on to always check with a central source via http before issuing addresses so that I can keep close track of all devices on a small specific purpose network. I've added an option called always_check under [http] and have functionally tested it. Please let me know what you think of this and if you would like changes before merging.